### PR TITLE
[12.0][FIX][carrier_environment] remove name from server env fields

### DIFF
--- a/carrier_environment/models/carrier_account.py
+++ b/carrier_environment/models/carrier_account.py
@@ -12,7 +12,6 @@ class CarrierAccount(models.Model):
     def _server_env_fields(self):
         carrier_fields = super()._server_env_fields
         carrier_fields.update({
-            "name": {},
             "account": {},
             "password": {},
             "file_format": {},


### PR DESCRIPTION
Remove name from server env fields as this should not change depending on the environment, since the name is actually used to retrieve the environment related data from the config file

@bealdav @angelmoya @gurneyalex 
Could you do a quick review please?