### PR TITLE
[12.0] Store the 'server.config' fields in sparse fields

### DIFF
--- a/server_environment/serv_config.py
+++ b/server_environment/serv_config.py
@@ -26,6 +26,7 @@ from itertools import chain
 
 from odoo import api, models, fields
 from odoo.tools.config import config as system_base_config
+from odoo.addons.base_sparse_field.models.fields import Serialized
 
 from .system_info import get_server_environment
 
@@ -156,6 +157,8 @@ class ServerConfiguration(models.TransientModel):
     _description = 'Display server configuration'
     _conf_defaults = _Defaults()
 
+    config = Serialized()
+
     @classmethod
     def _build_model(cls, pool, cr):
         """Add columns to model dynamically
@@ -193,6 +196,7 @@ class ServerConfiguration(models.TransientModel):
                     col_name,
                     fields.Char(
                         string=cls._format_key_display_name(col_name),
+                        sparse='config',
                         readonly=True)
                     )
             cls._conf_defaults[col_name] = value


### PR DESCRIPTION
This model is used only to display the configuration to authorized
users. It's a TransientModel that dynamically creates the fields for
every odoo configuration parameter, environment variables and some
system ones. Before this change, each new parameter/variable will
create a field in database, which can lead to many issues (lot of
fields, field name too long leading to a crash during the module upgrade).
Storing the fields in a single JSON field resolves these issues and is much cleaner anyway.