### PR TITLE
[13.0] Store the 'server.config' fields in sparse fields

### DIFF
--- a/server_environment/server_env.py
+++ b/server_environment/server_env.py
@@ -28,6 +28,8 @@ from lxml import etree
 from odoo import api, fields, models
 from odoo.tools.config import config as system_base_config
 
+from odoo.addons.base_sparse_field.models.fields import Serialized
+
 from .system_info import get_server_environment
 
 _logger = logging.getLogger(__name__)
@@ -172,6 +174,8 @@ class ServerConfiguration(models.TransientModel):
     _description = "Display server configuration"
     _conf_defaults = _Defaults()
 
+    config = Serialized()
+
     @classmethod
     def _build_model(cls, pool, cr):
         """Add columns to model dynamically
@@ -209,7 +213,9 @@ class ServerConfiguration(models.TransientModel):
                 ServerConfiguration,
                 col_name,
                 fields.Char(
-                    string=cls._format_key_display_name(col_name), readonly=True
+                    string=cls._format_key_display_name(col_name),
+                    sparse="config",
+                    readonly=True,
                 ),
             )
             cls._conf_defaults[col_name] = value


### PR DESCRIPTION
This model is used only to display the configuration to authorized
users. It's a TransientModel that dynamically creates the fields for
every odoo configuration parameter, environment variables and some
system ones. Before this change, each new parameter/variable will
create a field in database, which can lead to many issues (lot of
fields, field name too long). Storing the fields in a single JSON
field resolves these issues and is much cleaner anyway.