### PR TITLE
[12.0][PORT] server_environment. port static files controllers (from server-tools 8.0 branch)

### DIFF
--- a/server_environment/__init__.py
+++ b/server_environment/__init__.py
@@ -18,6 +18,7 @@
 #
 ##############################################################################
 from . import models
+from . import controllers
 # TODO when migrating to 12, fix the import of serv_config by renaming the
 # file?
 # Add an alias to access to the 'serv_config' module as it is shadowed

--- a/server_environment/__manifest__.py
+++ b/server_environment/__manifest__.py
@@ -9,7 +9,7 @@
         "base",
         "base_sparse_field",
     ],
-    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "author": "Camptocamp,GRAP,Odoo Community Association (OCA)",
     "summary": "move some configurations out of the database",
     "website": "http://github.com/OCA/server-env",
     "license": "GPL-3 or any later version",

--- a/server_environment/controllers/__init__.py
+++ b/server_environment/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/server_environment/controllers/main.py
+++ b/server_environment/controllers/main.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2019 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from werkzeug.utils import redirect
+from urllib.parse import urljoin
+
+from odoo.tools.config import config
+from odoo import http
+from odoo.http import request, Controller
+
+
+class ServerEnvironmentController(Controller):
+
+    @http.route(
+        '/server_environment_<module_extension>'
+        '/static/RUNNING_ENV/<local_path>',
+        type='http', auth='public')
+    def environment_redirect(self, module_extension, local_path, **kw):
+        # Note: module_extension is present to make working
+        # the module in normal configuration, with the folder
+        # server_environment_files and in demo configuration, with the
+        # module  server_environment_files_sample
+        running_env = config.get('running_env', "default")
+        IrConfigParameter = request.env['ir.config_parameter'].sudo()
+        base_url = IrConfigParameter.get_param('web.base.url', '')
+        new_path = "/server_environment_%s/static/%s/%s" % (
+            module_extension, running_env, local_path)
+        url = urljoin(base_url, new_path)
+        return redirect(url, 303)

--- a/server_environment/readme/CONFIGURE.rst
+++ b/server_environment/readme/CONFIGURE.rst
@@ -99,7 +99,9 @@ This module provides also the possibility to load static files depending
 on the environment.
 
 Create a file view/templates.xml, and insert a css file
-::
+
+```
+
     <odoo>
         <template id="login_layout_no_db" name="Login Layout"
                 inherit_id="web.login_layout" >
@@ -109,8 +111,14 @@ Create a file view/templates.xml, and insert a css file
             </xpath>
         </template>
     </odoo>
+
+```
+
 Then, create css files for each environment you have. exemple:
-::
+
+```
     /server_environment_files/static/dev/css.css
     /server_environment_files/static/prod/css.css
     ...
+
+```

--- a/server_environment/readme/CONFIGURE.rst
+++ b/server_environment/readme/CONFIGURE.rst
@@ -89,3 +89,28 @@ Keychain integration
 
 Read the documentation of the class `models/server_env_mixin.py
 <models/server_env_mixin.py>`_.
+
+
+
+Loading static files
+--------------------
+
+This module provides also the possibility to load static files depending
+on the environment.
+
+Create a file view/templates.xml, and insert a css file
+::
+    <odoo>
+        <template id="login_layout_no_db" name="Login Layout"
+                inherit_id="web.login_layout" >
+            <xpath expr="." position="inside">
+                <link rel="stylesheet"
+                href="/server_environment_files/static/RUNNING_ENV/css.css"/>
+            </xpath>
+        </template>
+    </odoo>
+Then, create css files for each environment you have. exemple:
+::
+    /server_environment_files/static/dev/css.css
+    /server_environment_files/static/prod/css.css
+    ...

--- a/server_environment/readme/CONFIGURE.rst
+++ b/server_environment/readme/CONFIGURE.rst
@@ -100,7 +100,6 @@ on the environment.
 
 Create a file view/templates.xml, and insert a css file
 
-```
 
     <odoo>
         <template id="login_layout_no_db" name="Login Layout"
@@ -112,13 +111,20 @@ Create a file view/templates.xml, and insert a css file
         </template>
     </odoo>
 
-```
 
 Then, create css files for each environment you have. exemple:
 
-```
+
     /server_environment_files/static/dev/css.css
     /server_environment_files/static/prod/css.css
     ...
 
-```
+**Note**
+
+Since Odoo handles bundle of assets, it is not possible to target all the qweb templates, but only
+the main ones :
+
+* ``web.login_layout`` for the login page
+* ``web.webclient_bootstrap`` for the main backend part
+* ``point_of_sale.index`` for the PoS front end part
+* ...

--- a/server_environment/readme/CONTRIBUTORS.rst
+++ b/server_environment/readme/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Thomas Binfeld <thomas.binsfeld@acsone.eu>
 * Stéphane Bidoul <stefane.bidoul@acsone.com>
+* Sylvain LE GAL (https://www.twitter.com/legalsylvain)

--- a/server_environment_files_sample/__manifest__.py
+++ b/server_environment_files_sample/__manifest__.py
@@ -5,11 +5,13 @@
 {
     "name": "Example server configuration environment files repository module",
     "version": "12.0.1.0.1",
-    "depends": ["base"],
-    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "depends": ["server_environment", "web"],
+    "author": "Camptocamp,GRAP,Odoo Community Association (OCA)",
     "summary": "sample config file for server_environment",
     "website": "http://github.com/OCA/server-env",
     "license": "GPL-3 or any later version",
     "category": "Tools",
-    "data": [],
+    "data": [
+        'views/templates.xml',
+    ],
 }

--- a/server_environment_files_sample/readme/CONTRIBUTORS.rst
+++ b/server_environment_files_sample/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Florent Xicluna (Wingo) <florent.xicluna@gmail.com>
 * Nicolas Bessi <nicolas.bessi@camptocamp.com>
+* Sylvain LE GAL (https://www.twitter.com/legalsylvain)

--- a/server_environment_files_sample/static/preprod/web_login.css
+++ b/server_environment_files_sample/static/preprod/web_login.css
@@ -1,0 +1,3 @@
+body .bg-100{
+    background-color:#AAFFAA !important;
+}

--- a/server_environment_files_sample/static/test/web_login.css
+++ b/server_environment_files_sample/static/test/web_login.css
@@ -1,0 +1,3 @@
+body .bg-100{
+    background-color:#AAFFFF !important;
+}

--- a/server_environment_files_sample/views/templates.xml
+++ b/server_environment_files_sample/views/templates.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2019-Today GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+
+    <template id="login_layout_no_db" name="Login Layout" inherit_id="web.login_layout" >
+        <xpath expr="." position="inside">
+            <link rel="stylesheet" href="/server_environment_files_sample/static/RUNNING_ENV/web_login.css"/>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This PR is the port of the PR against OCA / server-tools 8.0 branch. ([ref](https://github.com/OCA/server-tools/pull/1503))

It improves the module ``server_environment`` to have the possibility to use custom static files, depending on the environment.

# Usage

* Create a file view/templates.xml, and insert a css file, for exemple

```
    <template id="login_layout_no_db" name="Login Layout" inherit_id="web.login_layout" >
        <xpath expr="." position="inside">
            <link rel="stylesheet" href="/server_environment_files_sample/static/RUNNING_ENV/web_login.css"/>
        </xpath>
    </template>
```

Then create your custom css files in the according folders, in your ``server_environment_files`` folders

```

    /server_environment_files/static/dev/css.css
    /server_environment_files/static/prod/css.css
    ....

```

# Technical information

this module adds basically a new http controller, that catch dynamically the call of the URLs that match the pattern ``server_environment_files/static/RUNNING_ENV/<path>`` and make a redirection. 

# Sample

![image](https://user-images.githubusercontent.com/3407482/82485785-3c196000-9adc-11ea-8d50-10a2b868ce3c.png)

CC : Original reviewers : @fcayre, @quentinDupont
