### PR TITLE
Fix server_environment version

### DIFF
--- a/server_environment/__manifest__.py
+++ b/server_environment/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "server configuration environment files",
-    "version": "13.0.2.2.0",
+    "version": "13.0.2.2.1",
     "depends": ["base", "base_sparse_field"],
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "summary": "move some configurations out of the database",


### PR DESCRIPTION
The PR https://github.com/OCA/server-env/pull/45 has been merged manually and a new version was not bumped.

Would depend on https://github.com/OCA/oca-github-bot/pull/123 for automatic publication w/ nobump.

Meanwhile you can pin `odoo13-addon-server-environment-13.0.2.2.1.dev8`