### PR TITLE
[13.0] Create module server_environment_delivery

### DIFF
--- a/server_environment_delivery/__init__.py
+++ b/server_environment_delivery/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/server_environment_delivery/__manifest__.py
+++ b/server_environment_delivery/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Server Environment Delivery",
+    "summary": "Configure prod environment for delivery carriers",
+    "version": "13.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Operations/Inventory/Delivery",
+    "website": "https://github.com/OCA/server-env",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["delivery", "server_environment"],
+}

--- a/server_environment_delivery/models/__init__.py
+++ b/server_environment_delivery/models/__init__.py
@@ -1,0 +1,1 @@
+from . import delivery_carrier

--- a/server_environment_delivery/models/delivery_carrier.py
+++ b/server_environment_delivery/models/delivery_carrier.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class DeliveryCarrier(models.Model):
+    _name = "delivery.carrier"
+    _inherit = ["delivery.carrier", "server.env.mixin"]
+
+    @property
+    def _server_env_fields(self):
+        base_fields = super()._server_env_fields
+        delivery_fields = {"prod_environment": {}}
+        delivery_fields.update(base_fields)
+        return delivery_fields

--- a/server_environment_delivery/models/delivery_carrier.py
+++ b/server_environment_delivery/models/delivery_carrier.py
@@ -5,7 +5,7 @@ from odoo import models
 
 class DeliveryCarrier(models.Model):
     _name = "delivery.carrier"
-    _inherit = ["delivery.carrier", "server.env.mixin"]
+    _inherit = ["delivery.carrier", "server.env.techname.mixin", "server.env.mixin"]
 
     @property
     def _server_env_fields(self):

--- a/server_environment_delivery/readme/CONFIGURE.rst
+++ b/server_environment_delivery/readme/CONFIGURE.rst
@@ -1,0 +1,18 @@
+At the moment, the module only allows to define the field prod_environment by
+defining a `[delivery_carrier]` with `prod_environment` key as follows:
+
+Restrict usage of prod environment:
+
+  ```
+  [delivery_carrier]
+  prod_environment=False
+  ```
+
+Force usage of prod environment:
+
+  ```
+  [delivery_carrier]
+  prod_environment=False
+  ```
+
+If the key is not set, the user will still be able to switch the value.

--- a/server_environment_delivery/readme/CONTRIBUTORS.rst
+++ b/server_environment_delivery/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/server_environment_delivery/readme/DESCRIPTION.rst
+++ b/server_environment_delivery/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module allows to configure shipping methods according to server environment.

--- a/setup/server_environment_delivery/odoo/addons/server_environment_delivery
+++ b/setup/server_environment_delivery/odoo/addons/server_environment_delivery
@@ -1,0 +1,1 @@
+../../../../server_environment_delivery

--- a/setup/server_environment_delivery/setup.py
+++ b/setup/server_environment_delivery/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to configure shipping methods according to server environment.

At the moment, the module only allows to define the field prod_environment by
defining a `[delivery_carrier]` with `prod_environment` key as follows:

Restrict usage of prod environment:

  ```
  [delivery_carrier]
  prod_environment=False
  ```

Force usage of prod environment:

  ```
  [delivery_carrier]
  prod_environment=False
  ```

If the key is not set, the user will still be able to switch the value.