### PR TITLE
[FIX] Reverting External Dependency from PR22

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,1 @@
-delivery-carrier https://github.com/Timo17100-c2c/delivery-carrier 12.0-mig-base_delivery_carrier_label
+delivery-carrier


### PR DESCRIPTION
Main
-

[FIX] Taking away external dependency to OCA as the intended changes
provide by that external branch has already been merged at commit
https://github.com/oca/delivery-carrier/commit/a614331f1017f52e72
from PR https://github.com/OCA/delivery-carrier/pull/212

Reverts
-
This is reverting part of PR https://github.com/OCA/server-env/pull/22
https://github.com/OCA/server-env/commit/15fe7fe641f0a3a02c8bf8fb8ffe8c0a0459aaf7#r42478627

This recently appeared into our repos because of 
https://github.com/OCA/server-tools/commit/526cc3c 
where a new dependency to server-tools was added

```
server-tools/oca_dependencies.txt:storage
storage/oca_dependencies.txt:server-env
server-env/oca_dependencies.txt:delivery-carrier https://github.com/Timo17100-c2c/delivery-carrier 12.0-mig-base_delivery_carrier_label
```