### PR TITLE
[FIX] server_environment: moved load of running env to hooks

### DIFF
--- a/server_environment/serv_config.py
+++ b/server_environment/serv_config.py
@@ -49,8 +49,8 @@ _boolean_states = {'1': True, 'yes': True, 'true': True, 'on': True,
 
 def _load_running_env():
     if not system_base_config.get("running_env"):
-        _logger.debug("`running_env` not found. Using default = `test`.")
-        _logger.debug(
+        _logger.info("`running_env` not found. Using default = `test`.")
+        _logger.info(
             "We strongly recommend against using the rc file but instead use an "
             "explicit config file or env variable."
         )

--- a/server_environment/serv_config.py
+++ b/server_environment/serv_config.py
@@ -49,8 +49,8 @@ _boolean_states = {'1': True, 'yes': True, 'true': True, 'on': True,
 
 def _load_running_env():
     if not system_base_config.get("running_env"):
-        _logger.warning("`running_env` not found. Using default = `test`.")
-        _logger.warning(
+        _logger.debug("`running_env` not found. Using default = `test`.")
+        _logger.debug(
             "We strongly recommend against using the rc file but instead use an "
             "explicit config file or env variable."
         )


### PR DESCRIPTION
FIXES: https://github.com/OCA/server-env/issues/56

- Even when the app server_environment was not installed
the method load_running_env was triggering a warning in the
logger.