### PR TITLE
[IMP] server_environment_ir_config_parameter: display if parameter are defined by env

### DIFF
--- a/server_environment_ir_config_parameter/__manifest__.py
+++ b/server_environment_ir_config_parameter/__manifest__.py
@@ -13,6 +13,7 @@
         'server_environment',
     ],
     'data': [
+        'views/view_ir_config_parameter.xml',
     ],
     'demo': [
     ],

--- a/server_environment_ir_config_parameter/models/ir_config_parameter.py
+++ b/server_environment_ir_config_parameter/models/ir_config_parameter.py
@@ -1,7 +1,7 @@
 # Copyright 2016-2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.addons.server_environment import serv_config
 
@@ -12,6 +12,19 @@ SECTION = 'ir.config_parameter'
 class IrConfigParameter(models.Model):
 
     _inherit = 'ir.config_parameter'
+
+    is_environment = fields.Boolean(
+        string="Defined by environment",
+        compute="_compute_is_environment",
+        help="If check, the value in the database will be ignored"
+        " and alternatively, the system will use the key defined"
+        " in your odoo.cfg environment file.")
+
+    @api.multi
+    def _compute_is_environment(self):
+        for parameter in self:
+            parameter.is_environment = serv_config.has_option(
+                SECTION, parameter.key)
 
     @api.model
     def get_param(self, key, default=False):

--- a/server_environment_ir_config_parameter/readme/CONTRIBUTORS.rst
+++ b/server_environment_ir_config_parameter/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Stéphane Bidoul <stephane.bidoul@acsone.eu> (https://acsone.eu)
 * Thierry Ducrest <thierry.ducrest@camptocamp.com>
 * Gilles Meyomesse <gilles.meyomesse@acsone.eu> (https://acsone.eu)
+* Sylvain LE GAL (https://www.twitter.com/legalsylvain)

--- a/server_environment_ir_config_parameter/readme/ROADMAP.rst
+++ b/server_environment_ir_config_parameter/readme/ROADMAP.rst
@@ -1,4 +1,0 @@
-When the user modifies System Parameters that are defined in the config
-file, the changes are ignored. It would be nice to display which system
-parameters come from the config file and possibly make their key and value
-readonly in the user interface.

--- a/server_environment_ir_config_parameter/views/view_ir_config_parameter.xml
+++ b/server_environment_ir_config_parameter/views/view_ir_config_parameter.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2020 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record  id="view_ir_config_parameter_tree" model="ir.ui.view">
+        <field name="model">ir.config_parameter</field>
+        <field name="inherit_id" ref="base.view_ir_config_list"/>
+        <field name="arch" type="xml">
+            <field name="value" position="after">
+                <field name="is_environment"/>
+            </field>
+        </field>
+    </record>
+
+    <record  id="view_ir_config_parameter_form" model="ir.ui.view">
+        <field name="model">ir.config_parameter</field>
+        <field name="inherit_id" ref="base.view_ir_config_form"/>
+        <field name="arch" type="xml">
+            <field name="value" position="after">
+                <field name="is_environment"/>
+            </field>
+            <field name="key" position="attributes">
+                <attribute name="attrs">{'readonly': [('is_environment', '=', True)]}</attribute>
+            </field>
+            <field name="value" position="attributes">
+                <attribute name="attrs">{'readonly': [('is_environment', '=', True)]}</attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
- display in the config parameter list and form views the new field ``is_environment``, and make the ``key`` and ``value`` readonly if checked.
- remove the roadmap section.


![image](https://user-images.githubusercontent.com/3407482/96242429-c094df80-0fa3-11eb-959a-e07c72720474.png)


kind regards.