### PR TITLE
[13.0] Remove required from tech_name mixin

### DIFF
--- a/server_environment/models/server_env_tech_name_mixin.py
+++ b/server_environment/models/server_env_tech_name_mixin.py
@@ -34,8 +34,7 @@ class ServerEnvTechNameMixin(models.AbstractModel):
     # TODO: could leverage the new option for computable / writable fields
     # and get rid of some onchange / read / write code.
     tech_name = fields.Char(
-        required=True,
-        help="Unique name for technical purposes. " "Eg: server env keys.",
+        help="Unique name for technical purposes. Eg: server env keys.",
     )
 
     _server_env_section_name_field = "tech_name"


### PR DESCRIPTION
In some cases, we want to use a tech_name, but we do not use server
environment on all the records, so tech_name should not be required.