### PR TITLE
[13.0] SafeConfigParser is deprecated since python 3.2

### DIFF
--- a/server_environment/server_env.py
+++ b/server_environment/server_env.py
@@ -149,7 +149,7 @@ def _load_config_from_env(config_p):
 
 def _load_config():
     """Load the configuration and return a ConfigParser instance."""
-    config_p = configparser.SafeConfigParser()
+    config_p = configparser.ConfigParser()
     # options are case-sensitive
     config_p.optionxform = str
 


### PR DESCRIPTION
SafeConfigParser is a [deprecated alias](https://github.com/python/cpython/blob/55b78ce3c4e23abe4f27bf16d7968f8851532e47/Lib/configparser.py#L1225-L1235) to ConfigParser since long.