### PR TITLE
[13.0] Improvements on server.env.techname.mixin

### DIFF
--- a/server_environment/models/server_env_tech_name_mixin.py
+++ b/server_environment/models/server_env_tech_name_mixin.py
@@ -16,17 +16,11 @@ class ServerEnvTechNameMixin(models.AbstractModel):
     This mixin helps solve the problem by providing a tech name field
     and a cleanup machinery as well as a unique constrain.
 
-    To use this mixin add it to the _inherit attr of your module like:
-
-        _inherit = [
-            "my.model",
-            "server.env.techname.mixin",
-            "server.env.mixin",
-        ]
-
+    Use it in place of "server.env.mixin".
     """
 
     _name = "server.env.techname.mixin"
+    _inherit = "server.env.mixin"
     _description = "Server environment technical name"
     _sql_constraints = [
         ("tech_name_uniq", "unique(tech_name)", "`tech_name` must be unique!",)

--- a/server_environment/readme/CONTRIBUTORS.rst
+++ b/server_environment/readme/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@
 * Thomas Binfeld <thomas.binsfeld@acsone.eu>
 * Stéphane Bidoul <stefane.bidoul@acsone.com>
 * Simone Orsi <simahawk@gmail.com>
+* Iván Todorovich <ivan.todorovich@gmail.com>


### PR DESCRIPTION
ping @simahawk 

What do you think about this?

Re. the mixin inherit (https://github.com/OCA/server-env/commit/154090abb7a694948c2ff9a9b6809abdd85a8c0b), I guess it wasn't done like this before because one may use `server.env.techname.mixin` without `server.env.mixing` but I can't see why one would want to do that.. I find this way easier to use and in most cases saves a few line breaks
