### PR TITLE
[FIX] Update server_env_mixin.py to allow mail_environment migration

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -376,7 +376,7 @@ class ServerEnvMixin(models.AbstractModel):
         # (inherits), we want to override it with a new one
         if fieldname not in self._fields or self._fields[fieldname].inherited:
             base_field_cls = base_field.__class__
-            field_args = base_field.args.copy()
+            field_args = base_field.args.copy() if base_field.args else {}
             field_args.pop("_sequence", None)
             field_args.update({"sparse": "server_env_defaults", "automatic": True})
 


### PR DESCRIPTION
Fixup to server_environment to allow prevent error NoneType in server_env_mixin.py.
This change is necessary to proceed with PR [#82](https://github.com/OCA/server-env/pull/82).

Context:

fields.arg can be None thus `copy()` will fail.
Those circumstances are met when adding module `mail_environment`