### PR TITLE
fix special chars breaking config

### DIFF
--- a/server_environment/server_env.py
+++ b/server_environment/server_env.py
@@ -133,7 +133,7 @@ def _load_config_from_env(config_p):
 
 def _load_config():
     """Load the configuration and return a ConfigParser instance."""
-    config_p = configparser.ConfigParser()
+    config_p = configparser.ConfigParser(interpolation=None)
     # options are case-sensitive
     config_p.optionxform = str
 


### PR DESCRIPTION
When config contains special character % odoo fails to start with following error
```
configparser.InterpolationSyntaxError: '%' must be followed by '%'
```
I think interpolation should be disabled or better handled with some validation that will warn user about their config. This PR disables interpolation as suggested [here](https://stackoverflow.com/a/62592195/4957168)  