### PR TITLE
[[14.0][REF] make server_environment_ir_config_parameter compatible with server_environment_data_encryption

### DIFF
--- a/server_environment_ir_config_parameter/__init__.py
+++ b/server_environment_ir_config_parameter/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hook import post_init_keep_parameter_value

--- a/server_environment_ir_config_parameter/__manifest__.py
+++ b/server_environment_ir_config_parameter/__manifest__.py
@@ -10,7 +10,6 @@
     "author": "ACSONE SA/NV, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-env",
     "depends": ["server_environment"],
-    "data": [
-        "views/view_ir_config_parameter.xml",
-    ],
+    "post_init_hook": "post_init_keep_parameter_value",
+    "data": [],
 }

--- a/server_environment_ir_config_parameter/hook.py
+++ b/server_environment_ir_config_parameter/hook.py
@@ -1,0 +1,13 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def post_init_keep_parameter_value(cr, registry):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        env.cr.execute("""SELECT id, value FROM ir_config_parameter""")
+        result = env.cr.fetchall()
+        for config_id, value in result:
+            env["ir.config_parameter"].browse(config_id).write({"value": value})
+    return True

--- a/server_environment_ir_config_parameter/tests/test_server_environment_ircp.py
+++ b/server_environment_ir_config_parameter/tests/test_server_environment_ircp.py
@@ -15,7 +15,10 @@ class TestEnv(ServerEnvironmentCase):
         super().setUp()
         self.ICP = self.env["ir.config_parameter"]
         self.env_config = (
-            "[ir.config_parameter]\n" "ircp_from_config=config_value\n" "ircp_empty=\n"
+            "[ir.config_parameter.ircp_from_config]\n"
+            "value=config_value\n\n"
+            "[ir.config_parameter.ircp_empty]\n"
+            "value=\n\n"
         )
 
     def _load_xml(self, module, filepath):
@@ -49,7 +52,7 @@ class TestEnv(ServerEnvironmentCase):
         """We can't set parameters that are in config file"""
         with self.load_config(
             public=self.env_config, serv_config_class=ir_config_parameter
-        ):
+        ), self.load_config(public=self.env_config):
             # when creating, the value is overridden by config file
             self.ICP.set_param("ircp_from_config", "new_value")
             value = self.ICP.get_param("ircp_from_config")


### PR DESCRIPTION
This PR in draft state and is not necessarily meant to be merged, it will probably be best to aims the v16.
But I'd like to have feedback from the users on the proposed changes and this way adapt it if there is strong blocakge about the current changes.

So, the idea is to make `ir.config_parameter` inherit from `server.env.mixin` like any other `server_environment_*` modules.
It will standardize the module which seems nice to me, and this way make it compatible with `server_environment_data_encryption` which override the `server.env.mixin` mixin.
I guess in the future we could have the same problem with any other module which aims to override `server.env.mixin` in order to add features for all `server_environment_*` modules.

The main blocking point maybe is that refactore changes the format of the configuration file.
Indeed, the current module exects something like : 
```
[ir.config_parameter]
name1=value1
name2=value2
```

While after the refactore, we have something similar as the other `server_environement_*` modules : 

```
[ir.config_parameter.name1]
value=value1

[ir.config_parameter.name1]
value=value2
```

Since this configuration is made by developpers, and since usually when you install `server_environment_ir_config_parameter` you also install other `server_environment_*` modules, in my opinion, it is not a bad thing to go with this second format because this way it won't be different from the others `server_environment_*` modules.
But, if it is a real issue, maybe we could find a way to keep the old one. (But it would complexify the module)

I'll be happy to have the opinion of the users of this module.
@sbidoul @TDu @GillesTephaneMeyomesse @legalsylvain @sebastienbeau @gurneyalex @simahawk 