### PR TITLE
[14.0] [IMP] `server_environment`: don't print stack trace when the field can't be read

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -195,9 +195,9 @@ class ServerEnvMixin(models.AbstractModel):
                 value = getter(section_name, field_name)
             else:
                 value = getter(global_section_name, field_name)
-        except Exception:
-            _logger.exception(
-                "error trying to read field %s in section %s", field_name, section_name
+        except Exception as e:
+            _logger.error(
+                "Unable to read field %s in section %s: %s", field_name, section_name, e
             )
             return False
         return value


### PR DESCRIPTION
Sample log before:

```python-traceback
2022-07-12 14:25:43,330 88 ERROR odoodb_test odoo.addons.server_environment.models.server_env_mixin: error trying to read field FIELD_NAME in section SECTION_NAME
Traceback (most recent call last):
  File "/odoo/src/odoo/api.py", line 793, in get
    return field_cache[record._ids[0]]
KeyError: 1
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/odoo/src/odoo/fields.py", line 972, in __get__
    value = env.cache.get(record, self)
  File "/odoo/src/odoo/api.py", line 796, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'storage.backend(1,).served_by'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/odoo/external-src/server-env/server_environment/models/server_env_mixin.py", line 195, in _server_env_read_from_config
    value = getter(section_name, field_name)
  File "/usr/lib/python3.7/configparser.py", line 818, in getint
    fallback=fallback, **kwargs)
  File "/usr/lib/python3.7/configparser.py", line 808, in _get_conv
    **kwargs)
  File "/usr/lib/python3.7/configparser.py", line 802, in _get
    return conv(self.get(section, option, **kwargs))
ValueError: invalid literal for int() with base 10: ''
```

After:

```python-traceback
2022-07-12 14:25:43,330 88 ERROR odoodb_test odoo.addons.server_environment.models.server_env_mixin: Unable to read field FIELD_NAME in section SECTION_NAME: invalid literal for int() with base 10: ''
```