### PR TITLE
[14.0] s_env_ir_config_param: allow empty values

### DIFF
--- a/server_environment_ir_config_parameter/models/ir_config_parameter.py
+++ b/server_environment_ir_config_parameter/models/ir_config_parameter.py
@@ -29,8 +29,9 @@ class IrConfigParameter(models.Model):
     def get_param(self, key, default=False):
         value = super().get_param(key, default=None)
         if serv_config.has_option(SECTION, key):
+            allow_empty = self.env.context.get("icp_get_param__allow_empty")
             cvalue = serv_config.get(SECTION, key)
-            if not cvalue:
+            if not cvalue and not allow_empty:
                 raise UserError(
                     _("Key %s is empty in " "server_environment_file") % (key,)
                 )

--- a/server_environment_ir_config_parameter/tests/test_server_environment_ircp.py
+++ b/server_environment_ir_config_parameter/tests/test_server_environment_ircp.py
@@ -93,6 +93,10 @@ mail.catchall.alias=my_alias"""
             with self.assertRaises(UserError):
                 self.ICP.get_param("ircp_empty")
             self.assertEqual(self.ICP.get_param("ircp_nonexistant"), False)
+            # bypass empty: no error
+            self.ICP.with_context(icp_get_param__allow_empty=True).get_param(
+                "ircp_empty"
+            )
 
     def test_override_xmldata(self):
         with self.load_config(


### PR DESCRIPTION
Sometimes you really want an empty default value.
Make it possible on demand w/ a specific ctx key.