### PR TITLE
[16.0][FW] [14.0] [IMP] `server_environment`: don't print stack trace when the field can't be read

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -195,9 +195,9 @@ class ServerEnvMixin(models.AbstractModel):
                 value = getter(section_name, field_name)
             else:
                 value = getter(global_section_name, field_name)
-        except Exception:
-            _logger.exception(
-                "error trying to read field %s in section %s", field_name, section_name
+        except Exception as e:
+            _logger.error(
+                "Unable to read field %s in section %s: %s", field_name, section_name, e
             )
             return False
         return value


### PR DESCRIPTION
Port of #116 from 14.0 to 16.0.