### PR TITLE
[16][FIX] README to specify server_type instead of type to match the model

### DIFF
--- a/mail_environment/readme/CONFIGURE.rst
+++ b/mail_environment/readme/CONFIGURE.rst
@@ -28,7 +28,7 @@ Example of config file ::
   [incoming_mail.odoo_pop_mail1]
   server = mail.myserver.com
   port = 110
-  type = pop
+  server_type = pop
   is_ssl = 0
   attach = 0
   original = 0


### PR DESCRIPTION
It looks like the README config section used type, but the underlying model is actually server_type.