### PR TITLE
[FIX] server_environment: ensure _inverse_sparce is set

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -390,6 +390,12 @@ class ServerEnvMixin(models.AbstractModel):
             if hasattr(base_field, "selection"):
                 field_args["selection"] = base_field.selection
             field = base_field_cls(**field_args)
+            # inverse method is not set on readonly field by Odoo
+            # even there is a states attributes on this field
+            # here we ensure the inverse method is set if the field 
+            # is editable
+            if not field.inverse and field.is_editable():
+                field.inverse = field._inverse_sparse
             self._add_field(fieldname, field)
 
     @api.model


### PR DESCRIPTION
inverse method is not set on readonly field by Odoo even there is a states attributes on this field.
Here we ensure the inverse method is set if the field is editable