### PR TITLE
[IMP] mail_environment: ssl certificate auth

### DIFF
--- a/mail_environment/models/ir_mail_server.py
+++ b/mail_environment/models/ir_mail_server.py
@@ -16,10 +16,18 @@ class IrMailServer(models.Model):
             "smtp_port": {},
             "smtp_user": {},
             "smtp_pass": {},
+            "smtp_ssl_certificate": {},  # the value must be base64 encoded
+            "smtp_ssl_private_key": {},  # the value must be base64 encoded
             "smtp_encryption": {},
+            "smtp_authentication": {
+                "compute_default": "_compute_default_authentication"
+            },
         }
         mail_fields.update(base_fields)
         return mail_fields
+
+    def _compute_default_authentication(self):
+        return "login"
 
     @api.model
     def _server_env_global_section_name(self):

--- a/mail_environment/readme/CONFIGURE.rst
+++ b/mail_environment/readme/CONFIGURE.rst
@@ -38,3 +38,10 @@ Example of config file ::
 You will need to create 2 records in the database, one outgoing mail
 server with the field `name` set to "odoo_smtp_server1" and one
 incoming mail server with the field `name` set to "odoo_pop_mail1".
+
+It is possible to use a SSL certificate for SMTP authentication. In this case,
+you need to set the following entries in the configuration entry ::
+
+  smtp_authentication = certificate
+  smtp_ssl_certificate = <base64 encoded certificate>
+  smtp_ssl_private_key = <base64 encoded certificate>


### PR DESCRIPTION
Add support to configure outgoing mail server to use SSL certificate authentication through mail environment.