### PR TITLE
[16.0][IMP] Server env default fields string

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -401,7 +401,7 @@ class ServerEnvMixin(models.AbstractModel):
             base_field_cls = base_field.__class__
             field_args = base_field.args.copy() if base_field.args else {}
             field_args.pop("_sequence", None)
-            fieldlabel = "{} {}".format(field_args.get("string", ""), "Env Default")
+            fieldlabel = "{} {}".format(base_field.string or "", "Env Default")
             field_args.update(
                 {
                     "sparse": "server_env_defaults",


### PR DESCRIPTION
Not all fields have their string in the args, but `.string` returns the computed (based on field name) string if not set in the args.