### PR TITLE
[16.0][FIX] server_environment: string for field storing default value

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -401,7 +401,11 @@ class ServerEnvMixin(models.AbstractModel):
             base_field_cls = base_field.__class__
             field_args = base_field.args.copy() if base_field.args else {}
             field_args.pop("_sequence", None)
-            fieldlabel = "{} {}".format(field_args.get("string", ""), "Env Default")
+            namelabel = (
+                field_args.get("string", "")
+                or fieldname[: fieldname.rfind("_env_default")]
+            )
+            fieldlabel = "{} {}".format(namelabel, "Env Default")
             field_args.update(
                 {
                     "sparse": "server_env_defaults",


### PR DESCRIPTION
This fix avoids a possible collision in the string of field storing default value when the first part is empty and the string is then " Env Default".