### PR TITLE
[FIX] server_environment: default field label

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -401,7 +401,11 @@ class ServerEnvMixin(models.AbstractModel):
             base_field_cls = base_field.__class__
             field_args = base_field.args.copy() if base_field.args else {}
             field_args.pop("_sequence", None)
-            fieldlabel = "{} {}".format(field_args.get("string", ""), "Env Default")
+            if hasattr(base_field, "string"):
+                base_label = base_field.string
+            else:
+                base_label = field_args.get("string", "")
+            fieldlabel = "{} {}".format(base_label, "Env Default")
             field_args.update(
                 {
                     "sparse": "server_env_defaults",


### PR DESCRIPTION
If related field is not directly set (coming from inheritance) or string label is not specified explicitly, it might not have it in `args`, making it generate same default field labels, causing warnings in odoo.

Before this change you could get these kind of warnings:

```
2023-09-23 13:28:39,638 1 WARNING odoodb odoo.addons.base.models.ir_model:
Two fields (field1_env_default, field2_env_default) of your.model() have
the same label:  Env Default.
```
It would generate multiple fields having same label.

P.S. most likely same issue on 14.0, 16.0.