### PR TITLE
[FIX] Allow manual configuration of incoming mail server

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -404,6 +404,7 @@ class ServerEnvMixin(models.AbstractModel):
             fieldlabel = "{} {}".format(base_field.string or "", "Env Default")
             field_args.update(
                 {
+                    "readonly": False,
                     "sparse": "server_env_defaults",
                     "automatic": True,
                     "string": fieldlabel,


### PR DESCRIPTION
When manual configuring an incoming mail server, the changes are not saved.

The problem is because the fields are marked as readonly by the server environment module.

With this change it is allowed to manually add an incoming mail server. 