### PR TITLE
[15.0] auth_saml_environment: removes readonly attributes to allow provider creation

### DIFF
--- a/auth_saml_environment/models/auth_saml_provider.py
+++ b/auth_saml_environment/models/auth_saml_provider.py
@@ -8,6 +8,11 @@ class AuthSamlProvider(models.Model):
     _name = "auth.saml.provider"
     _inherit = ["auth.saml.provider", "server.env.mixin"]
 
+    # Mandatory to be able to create objects
+    idp_metadata = fields.Text(required=False)
+    sp_pem_public = fields.Char(required=False)
+    sp_pem_private = fields.Char(required=False)
+
     sp_pem_public_path = fields.Char(
         string="sp_pem_public_path env config value",
     )


### PR DESCRIPTION
Some readonly fields prevent the creation of a provider. Removing them as they will be managed by the env.

Following change in https://github.com/OCA/server-auth/pull/342

(edit @yvaucher adding link to the source of the issue)