### PR TITLE
[14.0][FIX] auth_saml_environment: no require on readonly fields

### DIFF
--- a/auth_saml_environment/models/auth_saml_provider.py
+++ b/auth_saml_environment/models/auth_saml_provider.py
@@ -8,6 +8,11 @@ class AuthSamlProvider(models.Model):
     _name = "auth.saml.provider"
     _inherit = ["auth.saml.provider", "server.env.mixin"]
 
+    # Non-mandatory to be able to create objects
+    idp_metadata = fields.Text(required=False)
+    sp_pem_public = fields.Char(required=False)
+    sp_pem_private = fields.Char(required=False)
+
     sp_pem_public_path = fields.Char(
         string="sp_pem_public_path env config value",
     )


### PR DESCRIPTION
Restore the usage of the form view by dropping the required condition on binary fields that are readonly.

Those fields became mandatory after https://github.com/OCA/server-auth/pull/342 but the module auth_saml_environment offer to use paths as a alternative config option for binaries thus those fields can be empty.