### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/auth_saml_environment/__manifest__.py
+++ b/auth_saml_environment/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": "Allows system administrator to authenticate with any account",
     "version": "14.0.1.0.0",
     "category": "base",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-env",
     "license": "AGPL-3",
     "depends": [


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.