### PR TITLE
[11.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/auth_oauth_environment/__manifest__.py
+++ b/auth_oauth_environment/__manifest__.py
@@ -5,7 +5,7 @@
     'version': '11.0.1.0.0',
     'category': 'Tools',
     'summary': 'Configure mail servers with server_environment_files',
-    'author': "Camptocamp SA, Odoo Community Association (OCA)",
+    'author': "Camptocamp, Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'website': 'http://odoo-community.org',
     'depends': [


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 11.0.