### PR TITLE
[IMP] server_environment: allow env variable conf

### DIFF
--- a/server_environment/README.rst
+++ b/server_environment/README.rst
@@ -74,6 +74,14 @@ used values are 'dev', 'test', 'production':
    [options]
    running_env=dev
 
+Or set the ``RUNNING_ENV`` or ``ODOO_STAGE`` environment variable. If
+both all are set config file will take the precedence on environment and
+``RUNNING_ENV`` over ``ODOO_STAGE``.
+
+``ODOO_STAGE`` is used for odoo.sh platform where we can't set
+``RUNNING_ENV``, possible observed values are ``production``,
+``staging`` and ``dev``
+
 Values associated to keys containing 'passw' are only displayed in the
 'dev' environment.
 

--- a/server_environment/readme/CONFIGURE.md
+++ b/server_environment/readme/CONFIGURE.md
@@ -5,6 +5,12 @@ used values are 'dev', 'test', 'production':
     [options]
     running_env=dev
 
+Or set the `RUNNING_ENV` or `ODOO_STAGE` environment variable. If both all are set config file
+will take the precedence on environment and `RUNNING_ENV` over `ODOO_STAGE`.
+
+`ODOO_STAGE` is used for odoo.sh platform where we can't set `RUNNING_ENV`, possible
+observed values are `production`, `staging` and `dev`
+
 Values associated to keys containing 'passw' are only displayed in the
 'dev' environment.
 

--- a/server_environment/server_env.py
+++ b/server_environment/server_env.py
@@ -45,13 +45,20 @@ _boolean_states = {
 
 def _load_running_env():
     if not system_base_config.get("running_env"):
-        _logger.info("`running_env` not found. Using default = `test`.")
-        _logger.info(
-            "We strongly recommend against using the rc file but instead use an "
-            "explicit config file or env variable."
-        )
-        # safe default
-        system_base_config["running_env"] = "test"
+        env_running_env = os.environ.get("RUNNING_ENV", os.environ.get("ODOO_STAGE"))
+        if env_running_env:
+            system_base_config["running_env"] = env_running_env
+        else:
+            _logger.info(
+                "`running_env` or `RUNNING_ENV`, `ODOO_STAGE` not found. "
+                "Using default = `test`."
+            )
+            _logger.info(
+                "We strongly recommend against using the rc file but instead use an "
+                "explicit config file or env variable."
+            )
+            # safe default
+            system_base_config["running_env"] = "test"
 
 
 _load_running_env()

--- a/server_environment/static/description/index.html
+++ b/server_environment/static/description/index.html
@@ -424,6 +424,12 @@ used values are ‘dev’, ‘test’, ‘production’:</p>
 [options]
 running_env=dev
 </pre>
+<p>Or set the <tt class="docutils literal">RUNNING_ENV</tt> or <tt class="docutils literal">ODOO_STAGE</tt> environment variable. If
+both all are set config file will take the precedence on environment and
+<tt class="docutils literal">RUNNING_ENV</tt> over <tt class="docutils literal">ODOO_STAGE</tt>.</p>
+<p><tt class="docutils literal">ODOO_STAGE</tt> is used for odoo.sh platform where we can’t set
+<tt class="docutils literal">RUNNING_ENV</tt>, possible observed values are <tt class="docutils literal">production</tt>,
+<tt class="docutils literal">staging</tt> and <tt class="docutils literal">dev</tt></p>
 <p>Values associated to keys containing ‘passw’ are only displayed in the
 ‘dev’ environment.</p>
 <p>If you don’t provide any value, test is used as a safe default.</p>

--- a/server_environment/tests/test_server_environment.py
+++ b/server_environment/tests/test_server_environment.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Camptocamp (https://www.camptocamp.com).
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
+import os
 from unittest.mock import patch
 
 from odoo.tools.config import config as odoo_config
@@ -37,7 +38,20 @@ class TestEnv(common.ServerEnvironmentCase):
 
     @patch.dict(odoo_config.options, {"running_env": "whatever"})
     def test_default_non_dev_env(self):
+        server_env._load_running_env()
         self._test_default(hidden_pwd=True)
+
+    @patch.dict(odoo_config.options, {"running_env": None})
+    @patch.dict(os.environ, {"RUNNING_ENV": "dev"})
+    def test_default_dev_from_environ(self):
+        server_env._load_running_env()
+        self._test_default()
+
+    @patch.dict(odoo_config.options, {"running_env": None})
+    @patch.dict(os.environ, {"ODOO_STAGE": "dev"})
+    def test_odoosh_dev_from_environ(self):
+        server_env._load_running_env()
+        self._test_default()
 
     @patch.dict(odoo_config.options, {"running_env": "testing"})
     def test_value_retrival(self):


### PR DESCRIPTION
I would like to propose a forward port of [one specific commit from v14](https://github.com/OCA/server-env/commit/4286429cba03173804ff5855eeb5f282227bbff2). This opens up compatibility with Odoo.sh.