### PR TITLE
[FIX] server_environment: compute_default assign

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -254,7 +254,7 @@ class ServerEnvMixin(models.AbstractModel):
 
     def _compute_server_env_from_default(self, field_name, options):
         if options and options.get("compute_default"):
-            self[field_name] = getattr(self, options["compute_default"])()
+            getattr(self, options["compute_default"])()
         else:
             default_field = self._server_env_default_fieldname(field_name)
             if default_field:


### PR DESCRIPTION
Revert "server_environment: Fix value assignation in compute from default"

This reverts commit c92c0da88d5fe17672767747905009096bbf209d.

This is breaking other modules using server environment.