### PR TITLE
[FIX] mail_environment: default computation

### DIFF
--- a/mail_environment/models/ir_mail_server.py
+++ b/mail_environment/models/ir_mail_server.py
@@ -27,7 +27,7 @@ class IrMailServer(models.Model):
         return mail_fields
 
     def _compute_default_authentication(self):
-        return "login"
+        self.update({"smtp_authentication": "login"})
 
     @api.model
     def _server_env_global_section_name(self):


### PR DESCRIPTION
fix the implementation of _compute_default_authentication to match what is expected by the mixin