### PR TITLE
[14.0][FIX] server_environment: test independent from the working env

### DIFF
--- a/server_environment/tests/common.py
+++ b/server_environment/tests/common.py
@@ -10,6 +10,12 @@ from odoo.tests import common
 import odoo.addons.server_environment.models.server_env_mixin as server_env_mixin
 from odoo.addons.server_environment import server_env
 
+CLEAN_ENV = {
+    var: value
+    for (var, value) in os.environ.items()
+    if var not in ("RUNNING_ENV", "ODOO_STAGE")
+}
+
 
 class ServerEnvironmentCase(common.SavepointCase):
     @contextmanager
@@ -24,13 +30,13 @@ class ServerEnvironmentCase(common.SavepointCase):
             server_env._dir = original_dir
 
     @contextmanager
-    def set_env_variables(self, public=None, secret=None):
-        newkeys = {}
+    def set_env_variables(self, public=None, secret=None, **env_vars):
+        newkeys = {**CLEAN_ENV, **env_vars}
         if public:
             newkeys["SERVER_ENV_CONFIG"] = public
         if secret:
             newkeys["SERVER_ENV_CONFIG_SECRET"] = secret
-        with patch.dict("os.environ", newkeys):
+        with patch.dict("os.environ", newkeys, clear=True):
             yield
 
     @contextmanager

--- a/server_environment/tests/test_environment_variable.py
+++ b/server_environment/tests/test_environment_variable.py
@@ -1,7 +1,6 @@
 # Copyright 2018 Camptocamp (https://www.camptocamp.com).
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-
 from unittest.mock import patch
 
 from odoo.tools.config import config as odoo_config
@@ -12,8 +11,11 @@ from .common import ServerEnvironmentCase
 
 
 class TestRunningEnvDefault(ServerEnvironmentCase):
+    @patch.dict(odoo_config.options, {"running_env": None})
     def test_running_env_default(self):
         """When var is not provided it defaults to `test`."""
+        with self.set_env_variables():
+            server_env._load_running_env()
         self.assertEqual(odoo_config["running_env"], "test")
 
 


### PR DESCRIPTION
This test was failing when running_env was set locally.