### PR TITLE
[17.0][FIX] server_environment: hide password for smtp connection

### DIFF
--- a/server_environment/server_env.py
+++ b/server_environment/server_env.py
@@ -312,7 +312,7 @@ class ServerConfiguration(models.TransientModel):
         should be secret.
         :return: list of secret keywords
         """
-        secret_keys = ["passw", "key", "secret", "token"]
+        secret_keys = ["passw", "key", "secret", "token", "smtp_pass"]
         return any(secret_key in key for secret_key in secret_keys)
 
     @api.model


### PR DESCRIPTION
Current issue: `smtp_pass` value which defined in `[outgoing_mail]` from `mail_environment` module will got exposed