### PR TITLE
[16.0][FWPORT] server_environment: fix default method not passed

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -407,6 +407,7 @@ class ServerEnvMixin(models.AbstractModel):
                     "sparse": "server_env_defaults",
                     "automatic": True,
                     "string": fieldlabel,
+                    "default": base_field.default,
                 }
             )
 


### PR DESCRIPTION
before this commit, default values were not populated in other environments. The problem was only seen with data_encryption which save all the values for all the environments.

- [x] https://github.com/OCA/server-env/pull/166
- [ ]  https://github.com/OCA/server-env/pull/222
