### PR TITLE
[17.0][FIX] server_environment: make sure field name has no space

### DIFF
--- a/server_environment/server_env.py
+++ b/server_environment/server_env.py
@@ -206,7 +206,7 @@ class ServerConfiguration(models.TransientModel):
             list(cls._get_system_cols().items()),
         )
         for col, value in cols:
-            col_name = col.replace(".", "_")
+            col_name = col.replace(".", "_").replace(" ", "_")
             tmp_field = fields.Char(
                 string=cls._format_key_display_name(col_name),
                 sparse="config",


### PR DESCRIPTION
The issue happens when using mail_environment and creating a new base with a configuration file where the name of the outgoing_mail server contains a space.(`[outgoing_mail.aws mail]` for example).
Odoo fails with a pg error, about ir_model_data constrains ir_model_data_name_nospaces not matched by “(7533, null, 2025-03-31 15:08:14.397798, 2025-03-31 15:08:14.397798, null, 1579, f, field_server_config__outgoing_mail_aws mail_smtp_host, server_environment, ir.model.fields)”.

It only happens when creating a new database, not when updating one.