### PR TITLE
[16.0] Fix inheritance of server env techname mixin

### DIFF
--- a/server_environment/models/server_env_tech_name_mixin.py
+++ b/server_environment/models/server_env_tech_name_mixin.py
@@ -16,17 +16,18 @@ class ServerEnvTechNameMixin(models.AbstractModel):
     This mixin helps solve the problem by providing a tech name field
     and a cleanup machinery as well as a unique constrain.
 
-    To use this mixin add it to the _inherit attr of your module like:
+    To use this mixin add it to the _inherit attr of your model like:
+    (instead of `server.env.mixin`)
 
         _inherit = [
             "my.model",
             "server.env.techname.mixin",
-            "server.env.mixin",
         ]
 
     """
 
     _name = "server.env.techname.mixin"
+    _inherit = "server.env.mixin"
     _description = "Server environment technical name"
     _sql_constraints = [
         (

--- a/server_environment/readme/CONFIGURE.rst
+++ b/server_environment/readme/CONFIGURE.rst
@@ -96,4 +96,5 @@ Server environment integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Read the documentation of the class `models/server_env_mixin.py
-<models/server_env_mixin.py>`_.
+<models/server_env_mixin.py>`_ and `models/server_env_tech_name_mixin.py
+<models/server_env_tech_name_mixin.py>`_

--- a/server_environment/readme/USAGE.rst
+++ b/server_environment/readme/USAGE.rst
@@ -19,6 +19,6 @@ If you want to have a technical name to reference::
 
     class StorageBackend(models.Model):
         _name = "storage.backend"
-        _inherit = ["storage.backend", "server.env.techname.mixin", "server.env.mixin"]
+        _inherit = ["storage.backend", "server.env.techname.mixin"]
 
         [...]


### PR DESCRIPTION
In case a model was inheriting both server.env.mixin and server.env.techname.mixin the value of _server_env_section_name_field was depending on the order in which the mixins were inherited on that model.

If server.env.mixin was inherit first as in:
_name = "my.model"
_inherit = ["my.model", "server.env.mixin", "server.env.techname.mixin"]

Then the value of _server_env_section_name would be `name`

If server.env.techname.mixin was inherit first as in: _name = "my.model"
_inherit = ["my.model", "server.env.techname.mixin", "server.env.mixin"]

Then the value of _server_env_section_name would be `tech_name`

To avoid this, since the server.env.techname.mixin changes an attribute of server.env.mixin, server.env.techname.mixin must inherit the server.env.mixin.

With this, only one of the mixins needs to be inherited and there cannot be any 'silent' issue, where the _server_env_section_name depends on the order on which mixins are inherited.