### PR TITLE
[FIX] server_environment_ir_config_parameter: Don't save values in DB

### DIFF
--- a/server_environment_ir_config_parameter/models/ir_config_parameter.py
+++ b/server_environment_ir_config_parameter/models/ir_config_parameter.py
@@ -34,42 +34,16 @@ class IrConfigParameter(models.Model):
                     _("Key %s is empty in " "server_environment_file") % (key,)
                 )
             if cvalue != value:
-                # we write in db on first access;
-                # should we have preloaded values in database at,
-                # server startup, modules loading their parameters
-                # from data files would break on unique key error.
-                if not self.env.context.get("_from_get_param", 0):
-                    # the check is to avoid recursion, for instance the mail
-                    # addon has an override in ir.config_parameter::write which
-                    # calls get_param if we are setting mail.catchall.alias and
-                    # this will cause an infinite recursion. We cut that
-                    # recursion by using the context check.
-                    #
-                    # The mail addon call to get_param expects to get the value
-                    # *before* the change, so we have to return the database
-                    # value in that case
-                    self.sudo().with_context(_from_get_param=1).set_param(key, cvalue)
-                    value = cvalue
+                value = cvalue
         if value is None:
             return default
         return value
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            key = vals.get("key")
-            if key and serv_config.has_option(SECTION, key):
-                # enforce value from config file
-                vals.update(value=serv_config.get(SECTION, key))
-        return super().create(vals_list)
-
-    def write(self, vals):
-        for rec in self:
-            key = vals.get("key", rec.key)
-            if serv_config.has_option(SECTION, key):
-                # enforce value from config file
-                newvals = dict(vals, value=serv_config.get(SECTION, key))
-            else:
-                newvals = vals
-            super(IrConfigParameter, rec).write(newvals)
-        return True
+    def read(self, _fields=None, load="_classic_read"):
+        res = super().read(_fields, load=load)
+        environment_values = [r for r in res if r["is_environment"]]
+        for environment_value in environment_values:
+            environment_value["value"] = serv_config.get(
+                SECTION, environment_value["key"]
+            )
+        return res

--- a/server_environment_ir_config_parameter/tests/test_server_environment_ircp.py
+++ b/server_environment_ir_config_parameter/tests/test_server_environment_ircp.py
@@ -48,10 +48,8 @@ class TestEnv(ServerEnvironmentCase):
             # read so it's created in db
             value = self.ICP.get_param("ircp_from_config")
             self.assertEqual(value, "config_value")
-            # now it's in db
-            res = self.ICP.search([("key", "=", "ircp_from_config")])
-            self.assertEqual(len(res), 1)
-            self.assertEqual(res.value, "config_value")
+            # It should not be saved in db
+            self.assertFalse(self.ICP.search([("key", "=", "ircp_from_config")]))
 
     def test_set_param_1(self):
         """We can't set parameters that are in config file"""
@@ -74,11 +72,11 @@ class TestEnv(ServerEnvironmentCase):
             res.unlink()
             res = self.ICP.search([("key", "=", "ircp_from_config")])
             self.assertEqual(len(res), 0)
-            # but the value is recreated when getting param again
+            # but the value should not be recreated when getting param again
             value = self.ICP.get_param("ircp_from_config")
             self.assertEqual(value, "config_value")
-            res = self.ICP.search([("key", "=", "ircp_from_config")])
-            self.assertEqual(len(res), 1)
+            # It should not be saved in db
+            self.assertFalse(self.ICP.search([("key", "=", "ircp_from_config")]))
 
     def test_set_param_2(self):
         """We can set parameters that are not in config file"""
@@ -120,18 +118,17 @@ class TestEnv(ServerEnvironmentCase):
         ):
             value = self.ICP.get_param("mail.catchall.alias")
             self.assertEqual(value, "my_alias")
-            res = self.ICP.search([("key", "=", "mail.catchall.alias")])
-            self.assertEqual(len(res), 1)
-            self.assertEqual(res.value, "my_alias")
+            # It should not be saved in db
+            self.assertFalse(self.ICP.search([("key", "=", "mail.catchall.alias")]))
 
     def test_write(self):
         # there's a write override, test it here
-        self._load_xml(
-            "server_environment_ir_config_parameter", "tests/config_param_test.xml"
-        )
         with self.load_config(
             public=self.env_config, serv_config_class=ir_config_parameter
         ):
+            self._load_xml(
+                "server_environment_ir_config_parameter", "tests/config_param_test.xml"
+            )
             ICP = self.ICP
             icp1 = ICP.search([("key", "=", "ircp_from_config")])
             self.assertEqual(icp1.value, "value_from_xml")
@@ -139,8 +136,8 @@ class TestEnv(ServerEnvironmentCase):
             self.assertEqual(icp2.value, "other_value_from_xml")
             # Ensures that each record has its own value at write
             (icp1 | icp2).write({"value": "test"})
-            self.assertEqual(icp1.value, "config_value")
-            self.assertEqual(icp2.value, "other_config_value")
+            self.assertEqual(icp1.value, "test")
+            self.assertEqual(icp2.value, "test")
             self.assertEqual(ICP.get_param(icp1.key), "config_value")
             self.assertEqual(ICP.get_param(icp2.key), "other_config_value")
 
@@ -165,5 +162,5 @@ class TestEnv(ServerEnvironmentCase):
             # Ensures each record has its own value at create
             self.assertEqual(
                 records.mapped("value"),
-                ["config_value_without_record", "other_config_value_without_record"],
+                ["NOPE", "NOPE"],
             )

--- a/server_environment_ir_config_parameter/views/view_ir_config_parameter.xml
+++ b/server_environment_ir_config_parameter/views/view_ir_config_parameter.xml
@@ -12,6 +12,9 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="value" position="after">
                 <field name="is_environment" />
             </field>
+            <field name="value" position="attributes">
+                <attribute name="invisible">is_environment</attribute>
+            </field>
         </field>
     </record>
 
@@ -27,6 +30,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             </field>
             <field name="value" position="attributes">
                 <attribute name="readonly">is_environment</attribute>
+                <attribute name="invisible">is_environment</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
When a system parameter doesn't exist on the production environment, the parameter is created with the environment value that is defined on the production system.

When this DB is exported to a local or other environment, where the environment value is NOT defined on the system, the DB uses the one that has been saved in the production DB.
It is totally unnecessary to store them in the DB, because the get_param function always gets them from the environment, when defined.
Also when you define them in a data file with following values:
```xml
    <record model="ir.config_parameter" id="ir_config_parameter_test">
        <field name="key">test</field>
        <field name="value">PLACEHOLDER</field>
    </record>
```
and the key is defined in the environment that one will also be used to create the system parameter, instead of the one defined in the data file.

There is logic in place that protects server environment defined fields from being updated at all, see https://github.com/OCA/server-env/pull/227

There is no need at all to store these values in the DB!

Everything also works fine when the system parameter is not defined at all.
It will not appear in the list view of the system parameters, but is viewable with the "Server Environment" action.