### PR TITLE
[16.0] [IMP] mail_environment: Add the `smtp_authentication` field to the `ir.mail_server` model

### DIFF
--- a/mail_environment/models/ir_mail_server.py
+++ b/mail_environment/models/ir_mail_server.py
@@ -17,6 +17,7 @@ class IrMailServer(models.Model):
             "smtp_user": {},
             "smtp_pass": {},
             "smtp_encryption": {},
+            "smtp_authentication": {},
         }
         mail_fields.update(base_fields)
         return mail_fields


### PR DESCRIPTION
This field is used to choose the authentication method, and used by core modules `google_gmail` and `microsoft_outlook`, for example, to define their own authentication methods.