### PR TITLE
[16.0] [FIX] mail_environment_google_gmail: fetchmail and docs

### DIFF
--- a/mail_environment_google_gmail/models/__init__.py
+++ b/mail_environment_google_gmail/models/__init__.py
@@ -1,1 +1,2 @@
+from . import fetchmail_server
 from . import ir_mail_server

--- a/mail_environment_google_gmail/models/fetchmail_server.py
+++ b/mail_environment_google_gmail/models/fetchmail_server.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class FetchmailServer(models.Model):
+    _inherit = "fetchmail.server"
+
+    @property
+    def _server_env_fields(self):
+        base_fields = super()._server_env_fields
+        gmail_fields = {
+            "google_gmail_authorization_code": {},
+            "google_gmail_refresh_token": {},
+        }
+        gmail_fields.update(base_fields)
+        return gmail_fields

--- a/mail_environment_google_gmail/readme/CONFIGURE.rst
+++ b/mail_environment_google_gmail/readme/CONFIGURE.rst
@@ -9,10 +9,18 @@ Example of config file ::
   smtp_port = 587
   smtp_user = example@gmail.com
   smtp_encryption = starttls
-  use_google_gmail_service = True
+  smtp_authentication = gmail
   google_gmail_authorization_code = YOUR_ACCOUNT_AUTH_CODE
   google_gmail_refresh_token = YOUR_REFRESH_TOKEN
 
+  [incoming_mail.gmail_imap_server]
+  server_type = gmail
+  smtp_host = imap.gmail.com
+  smtp_port = 993
+  user = example@gmail.com
+  is_ssl = 1
+  google_gmail_authorization_code = YOUR_ACCOUNT_AUTH_CODE
+  google_gmail_refresh_token = YOUR_REFRESH_TOKEN
 
 
 These two are global parameters, in core they're configured in General Settings:

--- a/mail_environment_google_gmail/readme/DESCRIPTION.rst
+++ b/mail_environment_google_gmail/readme/DESCRIPTION.rst
@@ -1,1 +1,1 @@
-This module allows to configure Gmail outgoing servers with server-env.
+This module allows to configure Gmail Authentication for email servers with server-env.


### PR DESCRIPTION
Odoo added support for Gmail Authentication for incoming mail servers in 16.0, and changed a little bit how to configure them.

This commit fixes the docs and adds the missing fetchmail server support.

Related to:
- https://github.com/OCA/server-env/pull/237