### PR TITLE
[18.0][IMP] server_environment: Add hook to find record name

### DIFF
--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -188,13 +188,16 @@ class ServerEnvMixin(models.AbstractModel):
 
     _server_env_section_name_field = "name"
 
+    def _server_env_record_name(self):
+        return self[self._server_env_section_name_field]
+
     def _server_env_section_name(self):
         """Name of the section in the configuration files
 
         Can be customized in your model
         """
         self.ensure_one()
-        val = self[self._server_env_section_name_field]
+        val = self._server_env_record_name()
         if not val:
             # special case: we have onchanges relying on tech_name
             # and we are testing them using `tests.common.Form`.


### PR DESCRIPTION
This hook allows to customize how the record name is found from the server env config, what can be useful if we want to identify records in server environment through M2o fields (eg in case records have same name in different companies)