### PR TITLE
[18.0][IMP] server_environment: Preserve not env managed data

### DIFF
--- a/mail_environment/migrations/18.0.1.0.1/post-migration.py
+++ b/mail_environment/migrations/18.0.1.0.1/post-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["ir.mail_server"]._preserve_not_env_managed_data(["smtp_authentication"])

--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -428,3 +428,31 @@ class ServerEnvMixin(models.AbstractModel):
             self._server_env_transform_field_to_read_from_env(field)
             self._server_env_add_is_editable_field(field)
         return
+
+    @api.model
+    def _preserve_not_env_managed_data(self, field_name_list):
+        """
+        Helper function typically used for hooks and migration scripts.
+        Restores database values for fields transitioning to 'server env managed'.
+
+        When a field is defined as managed by the server environment, Odoo
+        ignores the value stored in the database, prioritizing the environment
+        configuration instead. If no environment configuration exists, the field
+        may effectively lose its previous value.
+
+        This method forces to 'persist' these values if they are not
+        explicitly overridden by the current environment configuration.
+        """
+        self.env.cr.execute(f"SELECT * FROM {self._table}")
+        for row in self.env.cr.dictfetchall():
+            record = (
+                self.env[self._name]
+                .with_context(active_test=False)
+                .search([("id", "=", row["id"])])
+            )
+            if record:
+                record_values = {}
+                for field_name in field_name_list:
+                    if field_name in row:
+                        record_values[field_name] = row[field_name]
+                record.update(record_values)


### PR DESCRIPTION
Heavily inspired from https://github.com/OCA/server-env/pull/219, thank you @rven for your contribution.

I wanted to make @rven script more generic because this problem potentially happens every time we add the `server.env.mixin` to a model or when we add fields to the `_server_env_fields()` list.

------------------------------------------

Helper function typically used for hooks and migration scripts.
Restores database values for fields transitioning to 'server env managed'.

When a field is defined as managed by the server environment, Odoo ignores the value stored in the database, prioritizing the environment configuration instead. If no environment configuration exists, the field may effectively lose its previous value.

This method forces to 'persist' these values if they are not explicitly overridden by the current environment configuration.