### PR TITLE
[IMP] server_environment: module uninstallation

### DIFF
--- a/mail_environment/migrations/16.0.1.0.3/post-migration.py
+++ b/mail_environment/migrations/16.0.1.0.3/post-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["ir.mail_server"]._preserve_not_env_managed_data(["smtp_authentication"])

--- a/server_environment/README.rst
+++ b/server_environment/README.rst
@@ -203,6 +203,161 @@ If you want to have a technical name to reference::
 
         [...]
 
+Restoring columns on uninstall
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When ``server.env.mixin`` is bound to an existing model, the ORM drops the
+original stored columns for all env-managed fields. If the binding addon is
+later uninstalled, those columns must be recreated so the database remains
+usable.
+
+Add an ``uninstall_hook`` to your addon and delegate to
+``restore_env_managed_columns``::
+
+    # your_addon/__init__.py
+    from .hooks import uninstall_hook
+    # your_addon/hooks.py
+    from odoo import SUPERUSER_ID, api
+    from odoo.addons.server_environment import uninstall
+
+    def uninstall_hook(cr, registry):
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        uninstall.restore_env_managed_columns(
+            env,
+            "storage.backend",
+            ["directory_path", "other_field"],
+        )
+
+    # your_addon/__manifest__.py
+    {
+        ...
+        "uninstall_hook": "uninstall_hook",
+    }
+
+The helper creates any missing columns (idempotent: safe to call multiple
+times) and repopulates them with each record's current effective value —
+whether that value came from an environment configuration file or from the
+stored default field (``x_<field>_env_default``).
+
+The hook must run *before* the ORM extensions are removed, which is guaranteed
+by Odoo's uninstall sequence (hooks execute before
+``Module.module_uninstall()``).
+
+Handling required fields
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If a restored column is **required** (has a ``NOT NULL`` constraint) but has no
+effective value (missing from environment config and no default field set), the
+restoration will fail with a ``UserError``.
+
+**Solution:** pass a ``field_defaults`` dictionary with fallback values::
+
+    def uninstall_hook(cr, registry):
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        restore_env_managed_columns(
+            env,
+            "ir.mail_server",
+            ["smtp_host", "smtp_authentication"],
+            field_defaults={
+                "smtp_authentication": "login",  # fallback for required field
+            },
+        )
+
+The helper will use the fallback value if provided and the computed field value
+is empty. If no fallback is provided but a required field has no value, a
+``UserError`` is raised with instructions on how to provide a ``field_defaults``
+parameter.
+
+Migrating when dropping server_environment dependency
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When refactoring an existing addon that embeds a ``server.env.mixin`` binding, you
+may want to extract the binding into a separate *glue* addon and drop the
+``server_environment`` dependency from the original. This keeps the base addon
+lightweight while preserving server-environment features for those who install
+the glue addon.
+
+**Pattern:**
+
+- **Original addon (v1)**: depends on ``server_environment`` and binds the mixin
+  directly in model code.
+- **Refactored addon (v2)**: removes ``server_environment`` from dependencies,
+  removes the mixin binding and the related ORM model inheritance.
+- **New glue addon** (optional, same version): depends on both
+  ``server_environment`` and the original addon v2; re-adds the mixin binding in
+  a separate module file.
+
+**Migration checklist:**
+
+1. In the **original addon's v2** ``__manifest__.py``:
+
+   - Remove ``"server_environment"`` from ``depends``.
+   - Remove the model file(s) that contained the mixin binding.
+   - Update ``depends`` to add the new glue addon *if* the base addon still needs
+     it (otherwise, make the glue addon optional for users who want env-binding).
+
+2. In the **original addon's v2 model code**:
+
+   - Delete or simplify the model class that inherited from
+     ``server.env.mixin``.
+   - If the model was only there for the binding, remove it entirely.
+   - Restore the original field definitions (not as computed fields).
+
+3. **Create a migration script** (if needed) to restore columns *during the addon
+   upgrade*, before the ORM model extensions are unloaded. Use a ``@post_load``
+   hook or a dedicated migration script::
+
+       # migrations/18.0.1.0.0/post-restore-columns.py
+       def migrate(cr, version):
+           # Call the restoration logic while the v1 model is still active
+           env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+           # If any field is required and may have no value in the environment,
+           # provide a fallback via field_defaults
+           restore_env_managed_columns(
+               env,
+               "storage.backend",
+               ["directory_path", "other_field"],
+               field_defaults={
+                   "directory_path": "/tmp",  # fallback for required field
+               },
+           )
+
+4. **Create the glue addon** with the model re-inheritance::
+
+       # your_addon_env/__init__.py
+       from . import models
+
+       # your_addon_env/models/__init__.py
+       from . import storage_backend
+
+       # your_addon_env/models/storage_backend.py
+       class StorageBackend(models.Model):
+           _name = "storage.backend"
+           _inherit = ["storage.backend", "server.env.mixin"]
+
+           @property
+           def _server_env_fields(self):
+               return {"directory_path": {}}
+
+       # your_addon_env/__manifest__.py
+       {
+           "name": "Storage Backend – Server Environment",
+           "version": "18.0.1.0.0",
+           "depends": ["server_environment", "storage_backend"],
+           "installable": True,
+       }
+
+**Key points:**
+
+- Column restoration must happen *during the addon upgrade* (step 3), not as an
+  uninstall hook, because the original model binding is still active.
+- The ``restore_env_managed_columns`` helper is idempotent and safe to call even
+  if columns already exist.
+- Users who do not need server environment features simply do *not* install the
+  glue addon—the base addon continues to work with plain database columns.
+- Users who do need server environment can install both the base addon (v2+) and
+  the glue addon (same version) to get the binding back.
+
 Known issues / Roadmap
 ======================
 

--- a/server_environment/__init__.py
+++ b/server_environment/__init__.py
@@ -1,3 +1,4 @@
 from . import models
 from . import server_env
 from .server_env import serv_config, setboolean
+from . import uninstall

--- a/server_environment/models/server_env_mixin.py
+++ b/server_environment/models/server_env_mixin.py
@@ -425,3 +425,31 @@ class ServerEnvMixin(models.AbstractModel):
             self._server_env_transform_field_to_read_from_env(field)
             self._server_env_add_is_editable_field(field)
         return
+
+    @api.model
+    def _preserve_not_env_managed_data(self, field_name_list):
+        """
+        Helper function typically used for hooks and migration scripts.
+        Restores database values for fields transitioning to 'server env managed'.
+
+        When a field is defined as managed by the server environment, Odoo
+        ignores the value stored in the database, prioritizing the environment
+        configuration instead. If no environment configuration exists, the field
+        may effectively lose its previous value.
+
+        This method forces to 'persist' these values if they are not
+        explicitly overridden by the current environment configuration.
+        """
+        self.env.cr.execute(f"SELECT * FROM {self._table}")
+        for row in self.env.cr.dictfetchall():
+            record = (
+                self.env[self._name]
+                .with_context(active_test=False)
+                .search([("id", "=", row["id"])])
+            )
+            if record:
+                record_values = {}
+                for field_name in field_name_list:
+                    if field_name in row:
+                        record_values[field_name] = row[field_name]
+                record.update(record_values)

--- a/server_environment/readme/USAGE.rst
+++ b/server_environment/readme/USAGE.rst
@@ -22,3 +22,158 @@ If you want to have a technical name to reference::
         _inherit = ["storage.backend", "server.env.techname.mixin"]
 
         [...]
+
+Restoring columns on uninstall
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When ``server.env.mixin`` is bound to an existing model, the ORM drops the
+original stored columns for all env-managed fields. If the binding addon is
+later uninstalled, those columns must be recreated so the database remains
+usable.
+
+Add an ``uninstall_hook`` to your addon and delegate to
+``restore_env_managed_columns``::
+
+    # your_addon/__init__.py
+    from .hooks import uninstall_hook
+    # your_addon/hooks.py
+    from odoo import SUPERUSER_ID, api
+    from odoo.addons.server_environment import uninstall
+
+    def uninstall_hook(cr, registry):
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        uninstall.restore_env_managed_columns(
+            env,
+            "storage.backend",
+            ["directory_path", "other_field"],
+        )
+
+    # your_addon/__manifest__.py
+    {
+        ...
+        "uninstall_hook": "uninstall_hook",
+    }
+
+The helper creates any missing columns (idempotent: safe to call multiple
+times) and repopulates them with each record's current effective value —
+whether that value came from an environment configuration file or from the
+stored default field (``x_<field>_env_default``).
+
+The hook must run *before* the ORM extensions are removed, which is guaranteed
+by Odoo's uninstall sequence (hooks execute before
+``Module.module_uninstall()``).
+
+Handling required fields
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If a restored column is **required** (has a ``NOT NULL`` constraint) but has no
+effective value (missing from environment config and no default field set), the
+restoration will fail with a ``UserError``.
+
+**Solution:** pass a ``field_defaults`` dictionary with fallback values::
+
+    def uninstall_hook(cr, registry):
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        restore_env_managed_columns(
+            env,
+            "ir.mail_server",
+            ["smtp_host", "smtp_authentication"],
+            field_defaults={
+                "smtp_authentication": "login",  # fallback for required field
+            },
+        )
+
+The helper will use the fallback value if provided and the computed field value
+is empty. If no fallback is provided but a required field has no value, a
+``UserError`` is raised with instructions on how to provide a ``field_defaults``
+parameter.
+
+Migrating when dropping server_environment dependency
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When refactoring an existing addon that embeds a ``server.env.mixin`` binding, you
+may want to extract the binding into a separate *glue* addon and drop the
+``server_environment`` dependency from the original. This keeps the base addon
+lightweight while preserving server-environment features for those who install
+the glue addon.
+
+**Pattern:**
+
+- **Original addon (v1)**: depends on ``server_environment`` and binds the mixin
+  directly in model code.
+- **Refactored addon (v2)**: removes ``server_environment`` from dependencies,
+  removes the mixin binding and the related ORM model inheritance.
+- **New glue addon** (optional, same version): depends on both
+  ``server_environment`` and the original addon v2; re-adds the mixin binding in
+  a separate module file.
+
+**Migration checklist:**
+
+1. In the **original addon's v2** ``__manifest__.py``:
+
+   - Remove ``"server_environment"`` from ``depends``.
+   - Remove the model file(s) that contained the mixin binding.
+   - Update ``depends`` to add the new glue addon *if* the base addon still needs
+     it (otherwise, make the glue addon optional for users who want env-binding).
+
+2. In the **original addon's v2 model code**:
+
+   - Delete or simplify the model class that inherited from
+     ``server.env.mixin``.
+   - If the model was only there for the binding, remove it entirely.
+   - Restore the original field definitions (not as computed fields).
+
+3. **Create a migration script** (if needed) to restore columns *during the addon
+   upgrade*, before the ORM model extensions are unloaded. Use a ``@post_load``
+   hook or a dedicated migration script::
+
+       # migrations/18.0.1.0.0/post-restore-columns.py
+       def migrate(cr, version):
+           # Call the restoration logic while the v1 model is still active
+           env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+           # If any field is required and may have no value in the environment,
+           # provide a fallback via field_defaults
+           restore_env_managed_columns(
+               env,
+               "storage.backend",
+               ["directory_path", "other_field"],
+               field_defaults={
+                   "directory_path": "/tmp",  # fallback for required field
+               },
+           )
+
+4. **Create the glue addon** with the model re-inheritance::
+
+       # your_addon_env/__init__.py
+       from . import models
+
+       # your_addon_env/models/__init__.py
+       from . import storage_backend
+
+       # your_addon_env/models/storage_backend.py
+       class StorageBackend(models.Model):
+           _name = "storage.backend"
+           _inherit = ["storage.backend", "server.env.mixin"]
+
+           @property
+           def _server_env_fields(self):
+               return {"directory_path": {}}
+
+       # your_addon_env/__manifest__.py
+       {
+           "name": "Storage Backend – Server Environment",
+           "version": "18.0.1.0.0",
+           "depends": ["server_environment", "storage_backend"],
+           "installable": True,
+       }
+
+**Key points:**
+
+- Column restoration must happen *during the addon upgrade* (step 3), not as an
+  uninstall hook, because the original model binding is still active.
+- The ``restore_env_managed_columns`` helper is idempotent and safe to call even
+  if columns already exist.
+- Users who do not need server environment features simply do *not* install the
+  glue addon—the base addon continues to work with plain database columns.
+- Users who do need server environment can install both the base addon (v2+) and
+  the glue addon (same version) to get the binding back.

--- a/server_environment/static/description/index.html
+++ b/server_environment/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>server configuration environment files</title>
 <style type="text/css">
 
 /*
@@ -398,13 +398,20 @@ see the values contained in the defined secret keys
 <li><a class="reference internal" href="#server-environment-integration" id="toc-entry-6">Server environment integration</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#usage" id="toc-entry-7">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-8">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-9">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-10">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-11">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-12">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-13">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-7">Usage</a><ul>
+<li><a class="reference internal" href="#restoring-columns-on-uninstall" id="toc-entry-8">Restoring columns on uninstall</a><ul>
+<li><a class="reference internal" href="#handling-required-fields" id="toc-entry-9">Handling required fields</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#migrating-when-dropping-server-environment-dependency" id="toc-entry-10">Migrating when dropping server_environment dependency</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-11">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-12">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-13">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-14">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-15">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-16">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -535,9 +542,163 @@ class StorageBackend(models.Model):
 
     [...]
 </pre>
+<div class="section" id="restoring-columns-on-uninstall">
+<h3><a class="toc-backref" href="#toc-entry-8">Restoring columns on uninstall</a></h3>
+<p>When <tt class="docutils literal">server.env.mixin</tt> is bound to an existing model, the ORM drops the
+original stored columns for all env-managed fields. If the binding addon is
+later uninstalled, those columns must be recreated so the database remains
+usable.</p>
+<p>Add an <tt class="docutils literal">uninstall_hook</tt> to your addon and delegate to
+<tt class="docutils literal">restore_env_managed_columns</tt>:</p>
+<pre class="literal-block">
+# your_addon/__init__.py
+from .hooks import uninstall_hook
+# your_addon/hooks.py
+from odoo import SUPERUSER_ID, api
+from odoo.addons.server_environment import uninstall
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    uninstall.restore_env_managed_columns(
+        env,
+        &quot;storage.backend&quot;,
+        [&quot;directory_path&quot;, &quot;other_field&quot;],
+    )
+
+# your_addon/__manifest__.py
+{
+    ...
+    &quot;uninstall_hook&quot;: &quot;uninstall_hook&quot;,
+}
+</pre>
+<p>The helper creates any missing columns (idempotent: safe to call multiple
+times) and repopulates them with each record’s current effective value —
+whether that value came from an environment configuration file or from the
+stored default field (<tt class="docutils literal">x_&lt;field&gt;_env_default</tt>).</p>
+<p>The hook must run <em>before</em> the ORM extensions are removed, which is guaranteed
+by Odoo’s uninstall sequence (hooks execute before
+<tt class="docutils literal">Module.module_uninstall()</tt>).</p>
+<div class="section" id="handling-required-fields">
+<h4><a class="toc-backref" href="#toc-entry-9">Handling required fields</a></h4>
+<p>If a restored column is <strong>required</strong> (has a <tt class="docutils literal">NOT NULL</tt> constraint) but has no
+effective value (missing from environment config and no default field set), the
+restoration will fail with a <tt class="docutils literal">UserError</tt>.</p>
+<p><strong>Solution:</strong> pass a <tt class="docutils literal">field_defaults</tt> dictionary with fallback values:</p>
+<pre class="literal-block">
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    restore_env_managed_columns(
+        env,
+        &quot;ir.mail_server&quot;,
+        [&quot;smtp_host&quot;, &quot;smtp_authentication&quot;],
+        field_defaults={
+            &quot;smtp_authentication&quot;: &quot;login&quot;,  # fallback for required field
+        },
+    )
+</pre>
+<p>The helper will use the fallback value if provided and the computed field value
+is empty. If no fallback is provided but a required field has no value, a
+<tt class="docutils literal">UserError</tt> is raised with instructions on how to provide a <tt class="docutils literal">field_defaults</tt>
+parameter.</p>
+</div>
+</div>
+<div class="section" id="migrating-when-dropping-server-environment-dependency">
+<h3><a class="toc-backref" href="#toc-entry-10">Migrating when dropping server_environment dependency</a></h3>
+<p>When refactoring an existing addon that embeds a <tt class="docutils literal">server.env.mixin</tt> binding, you
+may want to extract the binding into a separate <em>glue</em> addon and drop the
+<tt class="docutils literal">server_environment</tt> dependency from the original. This keeps the base addon
+lightweight while preserving server-environment features for those who install
+the glue addon.</p>
+<p><strong>Pattern:</strong></p>
+<ul class="simple">
+<li><strong>Original addon (v1)</strong>: depends on <tt class="docutils literal">server_environment</tt> and binds the mixin
+directly in model code.</li>
+<li><strong>Refactored addon (v2)</strong>: removes <tt class="docutils literal">server_environment</tt> from dependencies,
+removes the mixin binding and the related ORM model inheritance.</li>
+<li><strong>New glue addon</strong> (optional, same version): depends on both
+<tt class="docutils literal">server_environment</tt> and the original addon v2; re-adds the mixin binding in
+a separate module file.</li>
+</ul>
+<p><strong>Migration checklist:</strong></p>
+<ol class="arabic">
+<li><p class="first">In the <strong>original addon’s v2</strong> <tt class="docutils literal">__manifest__.py</tt>:</p>
+<ul class="simple">
+<li>Remove <tt class="docutils literal">&quot;server_environment&quot;</tt> from <tt class="docutils literal">depends</tt>.</li>
+<li>Remove the model file(s) that contained the mixin binding.</li>
+<li>Update <tt class="docutils literal">depends</tt> to add the new glue addon <em>if</em> the base addon still needs
+it (otherwise, make the glue addon optional for users who want env-binding).</li>
+</ul>
+</li>
+<li><p class="first">In the <strong>original addon’s v2 model code</strong>:</p>
+<ul class="simple">
+<li>Delete or simplify the model class that inherited from
+<tt class="docutils literal">server.env.mixin</tt>.</li>
+<li>If the model was only there for the binding, remove it entirely.</li>
+<li>Restore the original field definitions (not as computed fields).</li>
+</ul>
+</li>
+<li><p class="first"><strong>Create a migration script</strong> (if needed) to restore columns <em>during the addon
+upgrade</em>, before the ORM model extensions are unloaded. Use a <tt class="docutils literal">&#64;post_load</tt>
+hook or a dedicated migration script:</p>
+<pre class="literal-block">
+# migrations/18.0.1.0.0/post-restore-columns.py
+def migrate(cr, version):
+    # Call the restoration logic while the v1 model is still active
+    env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+    # If any field is required and may have no value in the environment,
+    # provide a fallback via field_defaults
+    restore_env_managed_columns(
+        env,
+        &quot;storage.backend&quot;,
+        [&quot;directory_path&quot;, &quot;other_field&quot;],
+        field_defaults={
+            &quot;directory_path&quot;: &quot;/tmp&quot;,  # fallback for required field
+        },
+    )
+</pre>
+</li>
+<li><p class="first"><strong>Create the glue addon</strong> with the model re-inheritance:</p>
+<pre class="literal-block">
+# your_addon_env/__init__.py
+from . import models
+
+# your_addon_env/models/__init__.py
+from . import storage_backend
+
+# your_addon_env/models/storage_backend.py
+class StorageBackend(models.Model):
+    _name = &quot;storage.backend&quot;
+    _inherit = [&quot;storage.backend&quot;, &quot;server.env.mixin&quot;]
+
+    &#64;property
+    def _server_env_fields(self):
+        return {&quot;directory_path&quot;: {}}
+
+# your_addon_env/__manifest__.py
+{
+    &quot;name&quot;: &quot;Storage Backend – Server Environment&quot;,
+    &quot;version&quot;: &quot;18.0.1.0.0&quot;,
+    &quot;depends&quot;: [&quot;server_environment&quot;, &quot;storage_backend&quot;],
+    &quot;installable&quot;: True,
+}
+</pre>
+</li>
+</ol>
+<p><strong>Key points:</strong></p>
+<ul class="simple">
+<li>Column restoration must happen <em>during the addon upgrade</em> (step 3), not as an
+uninstall hook, because the original model binding is still active.</li>
+<li>The <tt class="docutils literal">restore_env_managed_columns</tt> helper is idempotent and safe to call even
+if columns already exist.</li>
+<li>Users who do not need server environment features simply do <em>not</em> install the
+glue addon—the base addon continues to work with plain database columns.</li>
+<li>Users who do need server environment can install both the base addon (v2+) and
+the glue addon (same version) to get the binding back.</li>
+</ul>
+</div>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h2><a class="toc-backref" href="#toc-entry-8">Known issues / Roadmap</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-11">Known issues / Roadmap</a></h2>
 <ul class="simple">
 <li>it is not possible to set the environment from the command line. A
 configuration file must be used.</li>
@@ -547,7 +708,7 @@ for computable / writable fields and get rid of some onchange / read / write cod
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-9">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-12">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/server-env/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -555,15 +716,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-10">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-13">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-11">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-14">Authors</a></h3>
 <ul class="simple">
 <li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-12">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-15">Contributors</a></h3>
 <ul class="simple">
 <li>Florent Xicluna (Wingo) &lt;<a class="reference external" href="mailto:florent.xicluna&#64;gmail.com">florent.xicluna&#64;gmail.com</a>&gt;</li>
 <li>Nicolas Bessi &lt;<a class="reference external" href="mailto:nicolas.bessi&#64;camptocamp.com">nicolas.bessi&#64;camptocamp.com</a>&gt;</li>
@@ -580,7 +741,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-13">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-16">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/server_environment/tests/test_server_environment.py
+++ b/server_environment/tests/test_server_environment.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 
 from odoo.tools.config import config as odoo_config
 
+from odoo.addons.server_environment.uninstall import restore_env_managed_columns
+
 from .. import server_env
 from . import common
 
@@ -61,3 +63,14 @@ class TestEnv(common.ServerEnvironmentCase):
             self.assertEqual(val, "testing")
             val = parser.get("external_service.ftp", "host")
             self.assertEqual(val, "sftp.example.com")
+
+    def test_restore_env_managed_columns_unknown_field(self):
+        """Helper gracefully skips a field that doesn't exist on the model."""
+        # Must not raise even when the field name doesn't exist.
+        restore_env_managed_columns(
+            self.env, "res.partner", ["__nonexistent_field_xyz__"]
+        )
+
+    def test_restore_env_managed_columns_no_fields(self):
+        """Helper is a no-op when given an empty field list."""
+        restore_env_managed_columns(self.env, "res.partner", [])

--- a/server_environment/uninstall.py
+++ b/server_environment/uninstall.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Camptocamp (https://www.camptocamp.com)
+import logging
+
+from psycopg2 import sql as psycopg2_sql
+
+from odoo.tools import sql
+
+_logger = logging.getLogger(__name__)
+
+
+def restore_env_managed_columns(env, model_name, field_names, field_defaults=None):
+    """Restore database columns for fields formerly managed via server.env.mixin.
+
+    When an addon binds ``server.env.mixin`` to an existing model, the ORM
+    drops the original stored columns.  Call this helper from an
+    ``uninstall_hook`` so those columns are recreated and repopulated
+    with their current effective values before the addon is removed.
+
+    The hook must run *while* the module's ORM extensions are still active
+    (guaranteed by Odoo's uninstall sequence: hooks execute before
+    ``Module.module_uninstall()``), so the env-computed fields are still
+    readable and their values can be written back to freshly created columns.
+
+    The operation is idempotent: calling it multiple times will not fail.
+
+    **Defaults:** If a restored field value is NULL/empty, the helper will
+    use the fallback from ``field_defaults`` (if provided) or the field's
+    ORM-level default (if defined).
+
+    Note: ``field.required`` is set to False by the mixin, so we cannot detect
+    which fields are required. Provide explicit ``field_defaults`` for fields
+    that must have values.
+
+    :param str model_name: dotted model name, e.g. ``"ir.mail_server"``
+    :param field_names: iterable of field names whose columns to restore
+    :param dict field_defaults: optional mapping of field name to fallback
+        value used when restoring a column that has no effective env-computed
+        value, e.g. ``{"smtp_authentication": "<login>"}``
+    """
+    model = env[model_name]
+    cr = env.cr
+    field_defaults = field_defaults or {}
+
+    for field_name in field_names:
+        field = model._fields.get(field_name)
+        if field is None:
+            _logger.warning(
+                "restore_env_managed_columns: field %r not found on %s, skipping",
+                field_name,
+                model_name,
+            )
+            continue
+        column_type = field.column_type
+        if column_type is None:
+            _logger.warning(
+                "restore_env_managed_columns: "
+                "field %r on %s has no SQL column type, skipping",
+                field_name,
+                model_name,
+            )
+            continue
+        table = model._table
+        if not sql.column_exists(cr, table, field_name):
+            sql.create_column(cr, table, field_name, column_type[1], field.string)
+            _logger.info(
+                "restore_env_managed_columns: created column %s.%s (%s)",
+                table,
+                field_name,
+                column_type[1],
+            )
+        # Repopulate every existing record with the current computed value.
+        # The hook runs while the ORM extensions are still active, so the
+        # env-computed field is still readable via the normal accessor.
+        for record in model.search([]):
+            value = record[field_name]
+            # The ORM returns False for NULL on non-boolean fields; map
+            # that back to None so psycopg2 writes a proper SQL NULL.
+            if value is False and field.type != "boolean":
+                value = None
+            elif value == "":
+                value = None
+
+            # Try to get a default value if we have None.
+            # Note: field.required is False after mixin transformation,
+            # so we apply defaults for all None values when available.
+            if value is None:
+                if field_name in field_defaults:
+                    value = field_defaults[field_name]
+                elif field_name in model.default_get([field_name]):
+                    value = model.default_get([field_name])[field_name]
+
+            query = psycopg2_sql.SQL("UPDATE {} SET {} = %s WHERE id = %s").format(
+                psycopg2_sql.Identifier(table),
+                psycopg2_sql.Identifier(field_name),
+            )
+            cr.execute(query, (value, record.id))


### PR DESCRIPTION
Add a helper to manage the restoring of the database columns when a module using `server_environment` is uninstalled or the dependency on `server_environment` is dropped.

Document how to use the helper in an uninstall script or in an upgrade script (if a new version of the addon drops the dependency).

This is a backward port of #261