### PR TITLE
[18][FIX] server_environment_data_encryption: keep sibling env fields cache consistent

### DIFF
--- a/server_environment_data_encryption/models/server_env_mixin.py
+++ b/server_environment_data_encryption/models/server_env_mixin.py
@@ -74,6 +74,27 @@ class ServerEnvMixin(models.AbstractModel):
                 encrypted_data_obj._encrypted_store_json(
                     encrypted_data_name, values, env=env
                 )
+                # The env fields are non-stored computed fields with no field
+                # dependency on the storage. Their cache is therefore not
+                # updated when we store here: refresh the *sibling* fields from
+                # the values we just wrote, so that a constraint validating a
+                # sibling field (e.g. microsoft_outlook reading smtp_encryption
+                # while saving smtp_authentication) sees the current values.
+                # The written field is left untouched so later inverses of the
+                # same write still read its freshly-assigned value.
+                record._update_cache(
+                    {
+                        name: value
+                        for name, value in values.items()
+                        if (
+                            name in record._fields
+                            and name != field_name
+                            and not record.env.cache.contains(
+                                record, record._fields[name]
+                            )
+                        )
+                    }
+                )
 
     def action_change_env_data_encrypted_fields(self):
         action_id = self.env.context.get("params", {}).get("action")

--- a/server_environment_data_encryption/tests/models.py
+++ b/server_environment_data_encryption/tests/models.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, models
+from odoo.exceptions import ValidationError
 
 # pylint: disable=consider-merging-classes-inherited
 
@@ -13,6 +14,8 @@ class FakePartner(models.Model):
         base_fields = super()._server_env_fields
         partner_fields = {
             "city": {},
+            "street": {},
+            "street2": {},
         }
         partner_fields.update(base_fields)
         return partner_fields
@@ -20,3 +23,14 @@ class FakePartner(models.Model):
     @api.model
     def _server_env_global_section_name(self):
         return "partner"
+
+    @api.constrains("street")
+    def _check_street2_when_street(self):
+        """A constraint reading a sibling env field (``street2``) while another
+        env field (``street``) is written. It must see the current value of
+        ``street2``, not a stale one."""
+        for partner in self.filtered(lambda p: p.street):
+            if not partner.street2:
+                raise ValidationError(
+                    self.env._("Street2 is required when Street is set.")
+                )

--- a/server_environment_data_encryption/tests/test_server_environment_data_encrypt.py
+++ b/server_environment_data_encryption/tests/test_server_environment_data_encrypt.py
@@ -46,6 +46,24 @@ class TestServerEnvDataEncrypted(CommonDataEncrypted):
         self.assertEqual(partner.with_context(environment="test").city, "test city")
         self.assertEqual(partner.with_context(environment="prod").city, "prod city")
 
+    def test_constraint_reads_sibling_env_field(self):
+        """Writing an env field must not corrupt the cache of sibling env
+        fields read by a constraint in the same transaction.
+
+        Regression test: after a cache clear followed by a re-read (what the
+        web client does before saving a form), writing ``street`` used to leave
+        ``street2`` stale, so the constraint raised although ``street2`` was set.
+        """
+        from odoo.tests import Form
+
+        partner = self.env["res.partner"].create({"name": "Fake name"})
+        partner.write({"street": "Test street", "street2": "Test street2"})
+        # Simulate the web client save: clear the cache and re-read the record
+        # before writing, as odoo.tests.Form does.
+        with Form(partner) as form:
+            form.street = "New street"
+        self.assertEqual(partner.street2, "Test street2")
+
     def test_view_with_env_update(self):
         self.maxDiff = None
         # common class already set test environment (as default)


### PR DESCRIPTION
server.env.mixin env fields are non-stored computed fields whose value is read from encrypted.data. They have no field dependency on that storage, so writing one of them (through the inverse) does not recompute the others. In the web client save flow, a constraint that reads a sibling env field (e.g. microsoft_outlook validating smtp_encryption/smtp_user while smtp_authentication is saved) then sees a stale/empty value and raises a spurious ValidationError.
    
In _inverse_server_env, after storing the new value, refresh the cache of the sibling env fields from the values just written. Fields already present in cache are left untouched so a multi-field write does not clobber the freshly assigned values.

Steps to reproduce : install Odoo with microsf_outlook module.
Set the Connection Encryption to TLS and save.
Then select outlook on the "Authenticate with" field and save => You'll get a validation error from a constraint about the Connection Encryption that must be with TLS value, while it actually already is...
<img width="1920" height="808" alt="image" src="https://github.com/user-attachments/assets/250360bb-302b-4c04-8340-9da6b3933329" />

<img width="1919" height="873" alt="image" src="https://github.com/user-attachments/assets/9754a0ab-d0c5-4f88-865b-461601566c9b" />
