### PR TITLE
[FIX] server_environment: prevent import errors for test classes

### DIFF
--- a/server_environment/tests/test_preserve_not_env_managed_data.py
+++ b/server_environment/tests/test_preserve_not_env_managed_data.py
@@ -1,8 +1,6 @@
 # Copyright 2026 Camptocamp SA
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
-from odoo_test_helper import FakeModelLoader
-
 from . import common
 
 
@@ -10,6 +8,9 @@ class TestPreserveNotEnvManagedData(common.ServerEnvironmentCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # Avoid import errors by other repos depending on server env test classes
+        from odoo_test_helper import FakeModelLoader
+
         cls.loader = FakeModelLoader(cls.env, cls.__module__)
         cls.loader.backup_registry()
         cls._origin_fields = {}


### PR DESCRIPTION
Test suites in other repositories are failing when they don't rely already on odoo-test-helper. Example:

File /__w/edi/edi/account_invoice_export_server_env/tests/__init__.py, line 1, in <module>
    from . import test_transmit_method
  File /__w/edi/edi/account_invoice_export_server_env/tests/test_transmit_method.py, line 8, in <module>
    from odoo.addons.server_environment.tests.common import ServerEnvironmentCase
  File /opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/server_environment/tests/__init__.py, line 3, in <module>
    from . import test_preserve_not_env_managed_data
  File /opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/server_environment/tests/test_preserve_not_env_managed_data.py, line 4, in <module>
    from odoo_test_helper import FakeModelLoader
ModuleNotFoundError: No module named 'odoo_test_helper'